### PR TITLE
fix(html): кириллические ссылки в урлах

### DIFF
--- a/spec/html_spec.rb
+++ b/spec/html_spec.rb
@@ -122,5 +122,23 @@ describe StringTools::HTML do
         end
       end
     end
+
+    context 'unicode domains' do
+      subject { StringTools::HTML.remove_links(html, whitelist: ['фермаежей.рф']) }
+
+      let(:html) do
+        <<-MARKUP
+          <a href="https://www.фермаежей.рф">www.фермаежей.рф</a>
+          <a href="https://www.мояфермаежей.рф">www.мояфермаежей.рф</a>
+        MARKUP
+      end
+
+      it 'should keep relative links' do
+        is_expected.to eq(<<-MARKUP)
+          <a href="https://www.фермаежей.рф">www.фермаежей.рф</a>
+          www.мояфермаежей.рф
+        MARKUP
+      end
+    end
   end
 end

--- a/spec/string_tools_spec.rb
+++ b/spec/string_tools_spec.rb
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 require 'spec_helper'
 
 describe StringTools do
@@ -16,6 +18,18 @@ describe StringTools do
       origin_str = '<table><tr><td style="text-align: center;"></td></tr></table>'
       sanitized_string = described_class.sanitize(origin_str)
       expect(sanitized_string).to eq origin_str
+    end
+
+    it 'normalize unicode urls in img src attribute' do
+      origin_str = '<img src="http://www.фермаежей.рф/images/foo.png">'
+      sanitized_string = described_class.sanitize(origin_str)
+      expect(sanitized_string).to eq '<img src="http://www.xn--80ajbaetq5a8a.xn--p1ai/images/foo.png">'
+    end
+
+    it 'normalize unicode urls in a href attribute' do
+      origin_str = '<a href="http://www.фермаежей.рф/">www.фермаежей.рф</a>'
+      sanitized_string = described_class.sanitize(origin_str)
+      expect(sanitized_string).to eq '<a href="http://www.xn--80ajbaetq5a8a.xn--p1ai/">www.фермаежей.рф</a>'
     end
   end
 end

--- a/string_tools.gemspec
+++ b/string_tools.gemspec
@@ -26,7 +26,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'addressable', '~> 2.3.2'
   spec.add_runtime_dependency 'ru_propisju', '~> 2.1.4'
   spec.add_runtime_dependency 'sanitize', '>= 3.1.2'
-  spec.add_runtime_dependency 'loofah', '>= 2.0.0'
+  spec.add_runtime_dependency 'nokogiri'
+  spec.add_runtime_dependency 'simpleidn', '>= 0.0.5'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
https://jira.railsc.ru/browse/SERVICES-594

старая логика заменяла unicode ссылки на представление в URI-encoding:

```
[97] pry(main)> Nokogiri::HTML::DocumentFragment.parse('<a href="http://www.фермаежей.рф/index.html">ссылка</a>').to_s
=> "<a href=\"http://www.%D1%84%D0%B5%D1%80%D0%BC%D0%B0%D0%B5%D0%B6%D0%B5%D0%B9.%D1%80%D1%84/index.html\">ссылка</a>"
```