### PR TITLE
chore(gemspec): update ru_propisju version

### DIFF
--- a/string_tools.gemspec
+++ b/string_tools.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'activesupport', '>= 3.1.12'
   spec.add_runtime_dependency 'rchardet19', '~> 1.3.5'
   spec.add_runtime_dependency 'addressable', '~> 2.3.2'
-  spec.add_runtime_dependency 'ru_propisju', '~> 2.1.4'
+  spec.add_runtime_dependency 'ru_propisju', '>= 2.1.4'
   spec.add_runtime_dependency 'sanitize', '>= 3.1.2'
   spec.add_runtime_dependency 'nokogiri'
   spec.add_runtime_dependency 'simpleidn', '>= 0.0.5'


### PR DESCRIPTION
Обновление версии гема 'ru_propisju'.
Необходимость обновления состоит в том, что при подключении гема [cosmos-treasury](https://github.com/abak-press/cosmos-treasury) в проект [crm_pulscen](https://github.com/abak-press/crm_pulscen) произошел конфликт версий гемов:
```
Bundler could not find compatible versions for gem "ru_propisju":
  In snapshot (Gemfile.lock):
    ru_propisju (= 2.5.0)

  In Gemfile:
    cosmos-treasury was resolved to 1.2.0, which depends on
      string_tools was resolved to 0.1.0, which depends on
        ru_propisju (~> 2.1.4)

    tulip was resolved to 0.30.2, which depends on
      ru_propisju (>= 2.3.0)
```
Данный реквест устраняет этот конфликт.