### PR TITLE
chore(gemspec): change addressable gem version

### DIFF
--- a/string_tools.gemspec
+++ b/string_tools.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'actionpack', '>= 3.1.12'
   spec.add_runtime_dependency 'activesupport', '>= 3.1.12'
   spec.add_runtime_dependency 'rchardet19', '~> 1.3.5'
-  spec.add_runtime_dependency 'addressable', '~> 2.3.2'
+  spec.add_runtime_dependency 'addressable', '>= 2.2.6'
   spec.add_runtime_dependency 'ru_propisju', '>= 2.1.4'
   spec.add_runtime_dependency 'sanitize', '>= 3.1.2'
   spec.add_runtime_dependency 'nokogiri'


### PR DESCRIPTION
Данный реквест позволяет разрешить конфликт при подключении гема [cosmos-tresury](https://github.com/abak-press/cosmos-treasury) к проекту [crm_pulscen](https://github.com/abak-press/crm_pulscen):
```
Bundler could not find compatible versions for gem "addressable":
  In snapshot (Gemfile.lock):
    addressable (= 2.2.6)

  In Gemfile:
    string_tools was resolved to 0.4.0, which depends on
      addressable (~> 2.3.2)

    tulip was resolved to 0.30.2, which depends on
      addressable (~> 2.2.6)
```