### PR TITLE
feature: сервис обрезания html-разметки

### DIFF
--- a/lib/string_tools/html.rb
+++ b/lib/string_tools/html.rb
@@ -2,6 +2,7 @@
 require 'nokogiri'
 require 'addressable/uri'
 require 'simpleidn'
+require_relative './html/truncate'
 
 module StringTools
   module HTML
@@ -13,6 +14,10 @@ module StringTools
       # http://stackoverflow.com/questions/24174032/prevent-nokogiri-from-url-encoding-src-attributes
       save_with: Nokogiri::XML::Node::SaveOptions::AS_XHTML
     }
+
+    def self.truncate(html, limit:)
+      Truncate.new(html, limit: limit).call
+    end
 
     # Public: Удаляет ссылки на неразрешенные домены
     #

--- a/lib/string_tools/html/truncate.rb
+++ b/lib/string_tools/html/truncate.rb
@@ -1,0 +1,112 @@
+module StringTools
+  module HTML
+    # Сервис безопасного обрезания текста, сожержащего html-разметку
+    # В отличии от https://github.com/hgmnz/truncate_html, может удалять и ненужные теги, если они становятся пусты,
+    # дополнительно удаляет изображения, если из-за них выходим за лимит
+    class Truncate
+      SERIALIZE_OPTIONS = {
+        indent: 0,
+        # сериализуем в xhtml, поскольку при сериализации в html, libxml2 делает чуть больше, чем хотелось бы:
+        # http://stackoverflow.com/questions/24174032/prevent-nokogiri-from-url-encoding-src-attributes
+        save_with: Nokogiri::XML::Node::SaveOptions::AS_XHTML
+      }.freeze
+
+      CLEAN_EMPTY_TAGS = %w(p).freeze
+
+      # Public:
+      # html - String, исходная разметка
+      # options:
+      #   limit - Integer, лимит, по которому обрезаем текcт
+      #   clean_empty_tags - Array of String, список тагов, которые можно удалять, если становятся пустыми
+      #   sericalize_options - Hash, опции сериализации
+      def initialize(html, limit:, clean_empty_tags: CLEAN_EMPTY_TAGS, serialize_options: SERIALIZE_OPTIONS)
+        @fragment = Nokogiri::HTML::DocumentFragment.parse(html)
+        @limit = limit
+        @clean_empty_tags = clean_empty_tags || []
+        @serialize_options = serialize_options.dup
+        @current = nil
+      end
+
+      # Public: Производим преобразвования
+      #
+      # Returns String.
+      def call
+        self.count = serialize.length - limit
+        self.current = find_starting_node
+
+        truncate! while count > 0 && current
+
+        if count > 0
+          ''
+        else
+          serialize
+        end
+      end
+
+      private
+
+      attr_reader :fragment, :limit, :clean_empty_tags, :serialize_options
+      attr_accessor :count, :current
+
+      def find_starting_node
+        fragment.xpath('.//text()|img'.freeze).last
+      end
+
+      def find_previous_sibling(node)
+        while node
+          node = node.previous_sibling
+          return node if truncate_class(node)
+        end
+      end
+
+      def truncate!
+        case truncate_class
+        when :text
+          truncate_text!
+        when :img
+          truncate_img!
+        else
+          raise 'unreachable'
+        end
+      end
+
+      def truncate_text!
+        if current.content.length <= count
+          unlink!
+        else
+          current.content = current.content[0...-count]
+          self.count = 0
+        end
+      end
+
+      def truncate_img!
+        unlink!
+      end
+
+      def unlink!
+        parent = current.parent
+        if parent && clean_empty_tags.include?(parent.name) && parent.children.count == 1
+          self.count -= parent.to_xhtml.length
+          parent.unlink
+        else
+          self.count -= current.to_xhtml.length
+          next_candidate = find_previous_sibling(current)
+          current.unlink
+        end
+
+        self.current = next_candidate || find_starting_node
+      end
+
+      def truncate_class(node = current)
+        return :text if node.is_a?(Nokogiri::XML::Text)
+        return :img if node.is_a?(Nokogiri::XML::Element) && node.name == 'img'.freeze
+        nil
+      end
+
+
+      def serialize
+        fragment.children.map { |node| node.serialize serialize_options }.join
+      end
+    end
+  end
+end

--- a/spec/string_tools/html/truncate_spec.rb
+++ b/spec/string_tools/html/truncate_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+
+RSpec.describe StringTools::HTML::Truncate do
+  describe '#call' do
+    subject { described_class.new(content, limit: limit).call }
+
+    context 'when content length is in limit' do
+      let(:content) { 'abcde' }
+      let(:limit) { content.length }
+
+      it { is_expected.to eq content }
+
+      context 'content is a img' do
+        let(:content) { '<img src="http://example.com/1.png" />' }
+        let(:limit) { content.length }
+
+        it { is_expected.to eq content }
+      end
+
+      context 'tag without content' do
+        let(:content) { '<p></p>' }
+        let(:limit) { content.length }
+
+        it { is_expected.to eq content }
+      end
+    end
+
+    context 'when simple content length is exceeded limit' do
+      let(:content) { '<p>abcde</p>' }
+      let(:limit) { 8 }
+
+      it { is_expected.to eq '<p>a</p>' }
+
+      context 'content is a img' do
+        let(:content) { '<img src="http://example.com/1.png" />' }
+        let(:limit) { content.length - 1 }
+
+        it { is_expected.to eq '' }
+      end
+
+      context 'content is a text with img' do
+        let(:content) { 'abc<img src="http://example.com/1.png" />' }
+        let(:limit) { content.length - 1 }
+
+        it { is_expected.to eq 'abc' }
+      end
+
+      context 'content is a img with text' do
+        let(:content) { '<img src="http://example.com/1.png" />abc' }
+        let(:limit) { content.length - 1 }
+
+        it { is_expected.to eq '<img src="http://example.com/1.png" />ab' }
+      end
+
+      context 'when anything can not be deleted' do
+        let(:content) { '<p></p>' }
+        let(:limit) { 6 }
+
+        it { is_expected.to eq '' }
+      end
+    end
+
+    context 'when content with sibling nodes length is exceeded limit' do
+      let(:content) { '<p>abcde</p><p>12345</p>' }
+      let(:limit) { 20 }
+
+      it { is_expected.to eq '<p>abcde</p><p>1</p>' }
+
+      context 'when last node should be deleted' do
+        let(:content) { '<p>abcde</p><p>12345</p>' }
+        let(:limit) { 8 }
+
+        it { is_expected.to eq '<p>a</p>' }
+      end
+    end
+
+    context 'table rows' do
+      let(:content) { '<tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr>' }
+      let(:expected) { '<tr><td></td><td></td></tr><tr><td></td><td></td></tr>' }
+      let(:limit) { expected.length }
+
+      it { is_expected.to eq expected }
+    end
+  end
+end


### PR DESCRIPTION
https://jira.railsc.ru/browse/SERVICES-2094

пришлось написать велосипед, т.к. существующие гемы имеют 2 общие проблемы:
- результат может выходить за лимит
  1. для гема https://github.com/hgmnz/truncate_html такое происходит, если текст не содержит знаков препинания(`xxxxyyyyzzzz`)
  2. гем https://github.com/jorgemanrubia/truncato не учитывает, что теги закрываются
- нет возможности указать, что можно удалять теги `img`