### PR TITLE
fix: exclude \n and \t in nonprintable characters

### DIFF
--- a/lib/string_tools/core_ext/string.rb
+++ b/lib/string_tools/core_ext/string.rb
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 require 'rchardet19'
 require 'addressable/uri'
 require 'active_support/core_ext/module'
@@ -213,7 +211,7 @@ class String
   #
   # Returns String
   def remove_nonprintable
-    gsub(/[^[:print:]]/i, '')
+    gsub(/[^[:print:]\n\t]/i, '')
   end
 
   # Public: removes all non-printable characters from string

--- a/spec/string_spec.rb
+++ b/spec/string_spec.rb
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 require 'spec_helper'
 
 describe String do
@@ -11,6 +9,18 @@ describe String do
     let(:string) { "\uFDD1string\uFFFE \uFFFFwith\uFDEF weird characters\uFDD0" }
 
     it { expect(string.remove_nonprintable).to eq 'string with weird characters' }
+
+    context 'when string with \n' do
+      let(:string) { "one\ntwo" }
+
+      it { expect(string.remove_nonprintable).to eq string }
+    end
+
+    context 'when string with \t' do
+      let(:string) { "one\ttwo" }
+
+      it { expect(string.remove_nonprintable).to eq string }
+    end
   end
 
   describe '#remove_nonprintable!' do


### PR DESCRIPTION
https://jira.railsc.ru/browse/GOODS-1352