### PR TITLE
chore: Set readonly gem/credentials on drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -29,4 +29,5 @@ build:
     volumes:
       - /home/data/drone/rubygems:/root/.gem/credentials
     commands:
+      - chmod 0600 /root/.gem/credentials
       - release-gem --public


### PR DESCRIPTION
Не хочет докер брать оригинальные права при монтировании папки. Попробую пока так