### PR TITLE
feat(translit): add keyboard layout switch&transliteration 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,31 @@ Or install it yourself as:
 
 TODO: Write usage instructions here
 
+### Transliteration
+
+Usage: ```StringTools.transliteration_variations(<string>)```.
+Method returns an Array of Strings. Returned strings are: given string, string in different keboard layout and transliteration of whichever of first two string happens to be in Russian.
+If there is a char in strng which isn't a part of RU <-> EN keyboard mapping, or string containes both Russian and English chars, only given string wrapped in Array is returned.
+Examples:
+```ruby
+StringTools.transliteration_variations('"Мы почитаем всех нулями, А единицами — себя." - А. С. Пушкин')
+=> ["\"Мы почитаем всех нулями, А единицами — себя.\" - А. С. Пушкин",
+  "@Vs gjxbnftv dct[ yekzvb? F tlbybwfvb — ct,z/@ - F/ C/ Geirby",
+  "\"My` pochitaem vsex nulyami, A ediniczami — sebya.\" - A. S. Pushkin"]
+```
+```ruby
+StringTools.transliteration_variations('Ntrcn d ytdthyjq hfcrkflrt')
+=> ["Ntrcn d ytdthyjq hfcrkflrt", "Текст в неверной раскладке", "Tekst v nevernoj raskladke"]
+```
+```ruby
+StringTools.transliteration_variations('Еуче шт цкщтп лунищфкв дфнщгею')
+=> ["Еуче шт цкщтп лунищфкв дфнщгею", "Text in wrong keyboard layout.", "Euche sht czkshhtp lunishhfkv dfns    hhge."]
+```
+```ruby
+StringTools.transliteration_variations('ﻮﻴﻜﻴﺒﻳﺪﻳ')
+=> ["ﻮﻴﻜﻴﺒﻳﺪﻳ"]
+```
+
 ## Development
 
 After checking out the repo, run `bundle install` to install dependencies. Then, run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/string_tools/core_ext/string.rb
+++ b/lib/string_tools/core_ext/string.rb
@@ -154,10 +154,11 @@ class String
     end
   end
 
+  WIN_1251_ENCODING = 'windows-1251'.freeze
   # shorthand
   def detect_encoding
     e = ::CharDet.detect(self)["encoding"]
-    e = 'windows-1251' if StringTools.cp1251_compatible_encodings.include?(e)
+    e = WIN_1251_ENCODING if StringTools::CharDet::CP1251_COMPATIBLE_ENCODINGS.include?(e)
     e
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'simplecov'
 
 SimpleCov.start do

--- a/spec/string_tools_spec.rb
+++ b/spec/string_tools_spec.rb
@@ -171,4 +171,70 @@ describe StringTools do
     it  { expect(StringTools.valid_utf8?('foobar')).to be true }
     it  { expect(StringTools.valid_utf8?(nil)).to be false }
   end
+
+  describe '#transliteration_variations' do
+    describe 'maps consitency' do
+      it do
+        expect(described_class::Transliteration::LAYOUT_EN_TO_RU_MAP.size).
+          to eq ::StringTools::Transliteration::LAYOUT_RU_TO_EN_MAP.keys.size
+      end
+      it do
+        expect(::StringTools::Transliteration::LAYOUT_EN_TO_RU_MAP.keys).
+          to match_array ::StringTools::Transliteration::LAYOUT_RU_TO_EN_MAP.values
+      end
+      it do
+        expect(::StringTools::Transliteration::LAYOUT_RU_TO_EN_MAP.keys).
+          to match_array ::StringTools::Transliteration::LAYOUT_EN_TO_RU_MAP.values
+      end
+    end
+
+    let(:subject) { described_class.transliteration_variations(str) }
+    context 'when english string' do
+      let(:str) { 'qwertyuiop[]asdfghjkl;\'zxcvbnm,./' }
+
+      it do
+        expect(subject).to match_array [str,
+                                        'йцукенгшщзхъфывапролджэячсмитьбю.',
+                                        'jczukengshshhzx``fy`vaproldzhe`yachsmit`byu.']
+      end
+    end
+
+    context 'when russian string' do
+      let(:str) { 'йцукенгшщзхъфывапролджэячсмитьбю.' }
+
+      it do
+        expect(subject).to match_array [str,
+                                        'qwertyuiop[]asdfghjkl;\'zxcvbnm,./',
+                                        'jczukengshshhzx``fy`vaproldzhe`yachsmit`byu.']
+      end
+    end
+
+    context 'when string has russian AND english chars' do
+      let(:str) { 'abc абв' }
+
+      it { expect(subject).to match_array [str] }
+    end
+
+    context 'when string has other language chars' do
+      let(:str) { 'ﻮﻴﻜﻴﺒﻳﺪﻳ' }
+
+      it { expect(subject).to match_array [str] }
+    end
+
+    context 'when upper case' do
+      let(:str) { 'AbCd' }
+
+      it 'preserve case' do
+        expect(subject).to match_array [str, 'ФиСв', 'FiSv']
+      end
+    end
+    context 'when string has other chars' do
+      let(:str) { '0123456789!*() -_=+ abc' }
+      it 'preserves them' do
+        expect(subject).to match_array [str,
+                                        '0123456789!*() -_=+ фис',
+                                        '0123456789!*() -_=+ fis']
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://jira.railsc.ru/browse/BPC-15151

Стандарт транслитерации - ГОСТ 7.79—2000(ISO 9, система Б)

Пока мы поддерживаем Ruby < 2.4, у нас будут проблемы со сменой регистра в не-ascii строках.
пока загнал в карты транслитерации заглавные буквы, что бы не мудрить лишний раз с mb_chars. Поскольку это константы, разницы особой нет. Но вообще фича задумывалась как регистронезависимая, и при обновлении руби надо будет их подправить.

UPD - выяснилось, что верхний регистр может и пригодится.