### PR TITLE
fix: convert to_utf8 correctly, without hidding errors

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -23,24 +23,6 @@ spec_step_common: &spec_step_common
   - bundle exec appraisal bundle exec rspec
 
 steps:
-- name: build on ruby2.2
-  image: abakpress/ruby-app:2.2-latest
-  environment:
-    TEST_DB_HOST: postgres
-    TEST_DB_NAME: docker
-    TEST_DB_USERNAME: postgres
-    BUNDLE_PATH: /bundle/2.2
-  <<: *spec_step_common
-
-- name: build on ruby2.3
-  image: abakpress/ruby-app:2.3-latest
-  environment:
-    TEST_DB_HOST: postgres
-    TEST_DB_NAME: docker
-    TEST_DB_USERNAME: postgres
-    BUNDLE_PATH: /bundle/2.3
-  <<: *spec_step_common
-
 - name: build on ruby2.4
   image: abakpress/ruby-app:2.4-latest
   environment:

--- a/Appraisals
+++ b/Appraisals
@@ -1,10 +1,4 @@
 # frozen_string_literal: true
-if RUBY_VERSION < '2.4'
-  appraise 'rails4.0' do
-    gem 'actionpack', '~> 4.0.0'
-    gem 'activesupport', '~> 4.0.0'
-  end
-end
 
 appraise 'rails4.2' do
   gem 'actionpack', '~> 4.2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in string_tools.gemspec
 gemspec
 
-gem 'actionpack', '~> 4.0.13', require: false
+gem 'actionpack', '~> 4.2.0', require: false

--- a/dip.yml
+++ b/dip.yml
@@ -1,8 +1,8 @@
 version: '1'
 
 environment:
-  DOCKER_RUBY_VERSION: 2.3
-  RUBY_IMAGE_TAG: 2.3-latest
+  DOCKER_RUBY_VERSION: 2.4
+  RUBY_IMAGE_TAG: 2.4-latest
   COMPOSE_FILE_EXT: development
   RAILS_ENV: test
 

--- a/lib/string_tools/core_ext/string.rb
+++ b/lib/string_tools/core_ext/string.rb
@@ -163,32 +163,21 @@ class String
     e
   end
 
-  def to_utf8!
-    self.replace(self.to_utf8)
+  def to_utf8(inplace = false)
+    return self if valid_encoding? && is_utf8?
+
+    source_enc = detect_encoding
+    return '' unless source_enc
+
+    encode_utf8(source_enc, inplace)
   end
 
-  def to_utf8
-    # и так utf
-    return self if is_utf8?
-
-    enc = detect_encoding
-
-    # если utf или английские буквы, то тоже ок
-    return self if ['utf-8', 'ascii'].include?(enc)
-
-    # если неизвестная каша, то возвращаем пустую строку
-    return '' if enc.nil?
-
-    # иначе пытаемся перекодировать
-    encode 'utf-8', enc, :undef => :replace, :invalid => :replace
-  rescue
-    ''
+  def to_utf8!
+    to_utf8(true)
   end
 
   def to_cp1251
-    encode 'cp1251', :undef => :replace, :invalid => :replace
-  rescue
-    ''
+    encode 'cp1251', undef: :replace, invalid: :replace, replace: ''
   end
 
   def to_cp1251!
@@ -229,6 +218,12 @@ class String
   end
 
   private
+
+  def encode_utf8(source_enc, inplace = false)
+    args = ['utf-8', source_enc, undef: :replace, invalid: :replace, replace: '']
+
+    inplace ? encode!(*args) : encode(*args)
+  end
 
   def surround_with_ansi(ascii_seq)
     "#{ascii_seq}#{protect_escape_of(ascii_seq)}#{ANSI_CLEAR}"

--- a/lib/string_tools/version.rb
+++ b/lib/string_tools/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module StringTools
-  VERSION = '0.16.0'
+  VERSION = '1.0.0'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,3 +7,4 @@ SimpleCov.start do
 end
 
 require 'string_tools'
+require 'pry-byebug'

--- a/spec/string_spec.rb
+++ b/spec/string_spec.rb
@@ -2,6 +2,30 @@
 require 'spec_helper'
 
 describe String do
+  describe '#to_utf8' do
+    let(:invalid_str) { "кирилиц\xD0".dup }
+
+    it do
+      expect(invalid_str).not_to be_valid_encoding
+      expect(invalid_str.to_utf8).to be_valid_encoding
+      expect(invalid_str.to_utf8.is_utf8?).to eq(true)
+      expect(invalid_str.to_utf8).to eq('кирилиц')
+    end
+  end
+
+  describe '#to_utf8!' do
+    let(:invalid_str) { "кирилиц\xD0".dup }
+
+    it do
+      expect(invalid_str).not_to be_valid_encoding
+      invalid_str.to_utf8!
+
+      expect(invalid_str).to be_valid_encoding
+      expect(invalid_str.is_utf8?).to eq(true)
+      expect(invalid_str).to eq('кирилиц')
+    end
+  end
+
   describe '#mb_downcase' do
     it { expect("Кириллица".mb_downcase).to eq("кириллица") }
   end

--- a/string_tools.gemspec
+++ b/string_tools.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'actionpack', '>= 4.0.13'
-  spec.add_runtime_dependency 'activesupport', '>= 4.0.13'
+  spec.add_runtime_dependency 'actionpack', '>= 4.2.0'
+  spec.add_runtime_dependency 'activesupport', '>= 4.2.0'
   spec.add_runtime_dependency 'rchardet19', '~> 1.3.5'
   spec.add_runtime_dependency 'addressable', '>= 2.3.2'
   spec.add_runtime_dependency 'ru_propisju', '>= 2.1.4'
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'nokogiri'
   spec.add_runtime_dependency 'simpleidn', '>= 0.0.5'
 
-  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'bundler', '~> 1.17.3'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '>= 3.4'
   spec.add_development_dependency 'appraisal', '>= 1.0.2'


### PR DESCRIPTION
https://jira.railsc.ru/browse/BPC-22244

- Раньше метод to_utf8 неправильно перекодировал строки, суть в том, что он выдавал бинарное представление и вроде кодировка как бе корректна была, но на самом деле строка не представляла собой utf-8:

Вот как работало раньше
![image](https://github.com/abak-press/string_tools/assets/751651/317281cd-ad93-41b9-9bb9-d734ef503a9f)

![image](https://github.com/abak-press/string_tools/assets/751651/fad9441d-91af-40e5-9df2-f41e0a0095dd)


![image](https://github.com/abak-press/string_tools/assets/751651/ce340e55-005b-4dc7-8ae4-086c3f40207a)


и такая некорректная строка вызывала проблемы

![image](https://github.com/abak-press/string_tools/assets/751651/517e0007-0dba-4cd0-b2b9-f1d904e0d43a)


В данном PR предлагаю _пытаться_ корректно перекодировать в utf-8 в случае, если строка не utf-8 или имеет невалидную кодировку, при этом не занулять всю строку, то есть отдавать пустую если "каша", а заменять невалидные символы пустотой.

Версия мажорная, потому что поведение по сути своей меняется, раньше ошибки игнорировались, теперь будет пытаться исправить строку